### PR TITLE
fix: resolve #13 — Rearrange sections of the home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -157,10 +157,22 @@ export default function Home() {
           <TaskInput onAddTask={addTask} />
         </section>
 
+        {/* All Tasks Section */}
+        <section className="mb-8">
+          <div className="flex items-center justify-between mb-4">
+             <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">All Tasks ({todoTasks.length})</h2>
+          </div>
+          <TaskList
+            tasks={tasks}
+            onUpdateTask={updateTask}
+            onDeleteTask={deleteTask}
+          />
+        </section>
+
         {/* Day Plan Generator */}
         <section className="mb-8">
           {!showPlan ? (
-            <button 
+            <button
               onClick={handleGeneratePlan}
               className="w-full flex items-center justify-center gap-2 py-3 border-2 border-dashed border-gray-300 dark:border-gray-700 rounded-xl text-gray-500 dark:text-gray-400 hover:border-gray-400 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-300 transition-all"
             >
@@ -200,17 +212,6 @@ export default function Home() {
         {/* Daily Notes Section */}
         <section className="mb-8">
             <DailyNotes userId={userId} onAddTask={addTask} />
-        </section>
-
-        <section>
-          <div className="flex items-center justify-between mb-4">
-             <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">All Tasks ({todoTasks.length})</h2>
-          </div>
-          <TaskList 
-            tasks={tasks} 
-            onUpdateTask={updateTask} 
-            onDeleteTask={deleteTask} 
-          />
         </section>
       </main>
       <AmbientSound />


### PR DESCRIPTION
Closes #13

## What this PR does
Automated fix for: **Rearrange sections of the home page**

## Issue description
**New section order:**
1. ✅ **Focused Session** (unchanged - stays at top per requirement)
2. ✅ **Quick Task Input** (stays at #2)
3. ✅ **All Tasks** (MOVED UP from #5 → #3) ⬆️
4. ✅ **Day Plan Generator** (stays at #4)
5. ✅ **Daily Notes & AI Dump** (stays at #5, now at bottom)
6. ✅ **Ambient Sound** (fixed bottom-right, unchanged)

## Agent output
<details>
<summary>Click to expand</summary>

```
Perfect! I've successfully rearranged the sections on the home page according to issue #13. 

## Changes Made

The sections have been reordered in `/tmp/jarvis-workspace/BrianTruong23_centralized_dashboard/src/app/page.tsx`:

**New section order:**
1. ✅ **Focused Session** (lines 108-154) - unchanged at top
2. ✅ **Quick Task Input** (lines 156-158) - stays at #2  
3. ✅ **All Tasks** (lines 160-170) - **MOVED UP** from position #5 → #3 ⬆️
4. ✅ **Day Plan Generator** (lines 172-210) - moved down from #3 → #4
5. ✅ **Daily Notes & AI Dump** (lines 212-215) - now at bottom (#5)
6. ✅ **Ambient Sound** (line 216) - remains fixed at bottom-right, unchanged

The "All Tasks" section has been moved up to appear right after the Quick Task Input, before the Day Plan Generator, exactly as specified in the issue requirements.

```

</details>

---
*Generated by [Jarvis22](https://github.com/BrianTruong23/Jarvis22)*
