### PR TITLE
fix: resolve #17 — API Key Exposure Risk - Fallback to NEXT_PUBLIC_GITHUB_APIKEY

### DIFF
--- a/src/app/api/github/issues/route.ts
+++ b/src/app/api/github/issues/route.ts
@@ -17,9 +17,9 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // Get token from environment variable
+    // Get token from environment variable (server-side only)
     // Support both GITHUB_APIKEY and GITHUB-APIKEY (though underscores are standard)
-    const token = process.env.GITHUB_APIKEY || process.env['GITHUB-APIKEY'] || process.env.NEXT_PUBLIC_GITHUB_APIKEY;
+    const token = process.env.GITHUB_APIKEY || process.env['GITHUB-APIKEY'];
 
     if (!token) {
       // Don't fail in production if token is missing - return helpful error

--- a/src/app/api/github/sync/route.ts
+++ b/src/app/api/github/sync/route.ts
@@ -6,9 +6,9 @@ import { NextRequest, NextResponse } from 'next/server';
  */
 export async function POST(request: NextRequest) {
   try {
-    // Get repo and token from environment variables
+    // Get repo and token from environment variables (server-side only)
     const repo = process.env.GITHUB_REPO || process.env['GITHUB-REPO'];
-    const token = process.env.GITHUB_APIKEY || process.env['GITHUB-APIKEY'] || process.env.NEXT_PUBLIC_GITHUB_APIKEY;
+    const token = process.env.GITHUB_APIKEY || process.env['GITHUB-APIKEY'];
 
     if (!repo) {
       return NextResponse.json(


### PR DESCRIPTION
Closes #17

## What this PR does
Automated fix for: **API Key Exposure Risk - Fallback to NEXT_PUBLIC_GITHUB_APIKEY**

## Issue description
API routes have a fallback to NEXT_PUBLIC_GITHUB_APIKEY which could expose secrets client-side

## Agent output
<details>
<summary>Click to expand</summary>

```
Perfect! ✅ **Issue #17 has been resolved successfully.**

## Summary of Changes

I've fixed the API key exposure risk by removing the insecure fallback to `NEXT_PUBLIC_GITHUB_APIKEY` in both API routes:

### Files Modified:
1. **src/app/api/github/issues/route.ts:22** - Removed `process.env.NEXT_PUBLIC_GITHUB_APIKEY` fallback
2. **src/app/api/github/sync/route.ts:11** - Removed `process.env.NEXT_PUBLIC_GITHUB_APIKEY` fallback

### Security Fix:
- **Before**: `const token = process.env.GITHUB_APIKEY || process.env['GITHUB-APIKEY'] || process.env.NEXT_PUBLIC_GITHUB_APIKEY;`
- **After**: `const token = process.env.GITHUB_APIKEY || process.env['GITHUB-APIKEY'];`

This ensures that the GitHub API key can only be accessed server-side and will never be exposed in the client-side JavaScript bundle, even if someone mistakenly sets a `NEXT_PUBLIC_GITHUB_APIKEY` environment variable.

The API routes will now only accept server-side environment variables (`GITHUB_APIKEY` or `GITHUB-APIKEY`), which is the secure approach for Next.js API routes.

```

</details>

---
*Generated by [Jarvis22](https://github.com/BrianTruong23/Jarvis22)*
