### PR TITLE
fix: resolve #7 — Features in Kanban Tasks are movable

### DIFF
--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -202,15 +202,15 @@ export const KanbanBoard = ({ initialIdeas, userId }: KanbanBoardProps) => {
                    </div>
                  )}
                  {ideas.filter(i => i.status === col.id).map(idea => (
-                   <div key={idea.id} className="bg-white p-3 rounded-lg shadow-sm border border-gray-100 group relative">
+                   <div key={idea.id} className="bg-white p-3 rounded-lg shadow-sm border border-gray-100 group relative" draggable={false}>
                       <button 
                         onClick={() => handleDelete(idea.id)}
                         className="absolute top-2 right-2 text-gray-300 hover:text-red-500 opacity-0 group-hover:opacity-100 transition-opacity"
                       >
                         <X size={14} />
                       </button>
-                      <h4 className="font-bold text-sm mb-1">{idea.title}</h4>
-                      {idea.description && <p className="text-xs text-gray-500 line-clamp-3 mb-3">{idea.description}</p>}
+                      <h4 className="font-bold text-sm mb-1" draggable={false}>{idea.title}</h4>
+                      {idea.description && <p className="text-xs text-gray-500 line-clamp-3 mb-3" draggable={false}>{idea.description}</p>}
                       
                       <div className="flex justify-between mt-auto pt-2 border-t border-gray-50">
                         {colIdx > 0 ? (


### PR DESCRIPTION
Closes #7

## What this PR does
Automated fix for: **Features in Kanban Tasks are movable**

## Issue description
Features in Kanban Tasks can move around in the log

## Agent output
<details>
<summary>Click to expand</summary>

```
Perfect! I've successfully fixed the issue. Here's what I did:

## Solution for Issue #7: Features in Kanban Tasks are movable

**Problem**: Feature cards in the Kanban board were unintentionally draggable in the browser, allowing them to be moved around accidentally.

**Fix Applied**: Added `draggable={false}` attribute to prevent native browser drag behavior on:
1. The feature card container div (line 205)
2. The title heading (line 212)
3. The description paragraph (line 213)

**Changes made in**: `src/components/KanbanBoard.tsx:205-213`

This prevents users from accidentally dragging feature cards around. The intended movement functionality (using the arrow buttons to move features between columns) remains fully functional and is the only way to reposition features now.

```

</details>

---
*Generated by [Jarvis22](https://github.com/BrianTruong23/Jarvis22)*
