### PR TITLE
fix: resolve #27 — Implement activity_log table (per-user rows) + logging hooks for tasks/projects/agent actions

### DIFF
--- a/activity_log_schema.sql
+++ b/activity_log_schema.sql
@@ -1,0 +1,46 @@
+/**
+ * ACTIVITY LOG TABLE SCHEMA
+ * Run this in your Supabase SQL Editor to create the activity_log table.
+ */
+
+-- Create the activity_log table
+create table public.activity_log (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users,
+  actor text not null check (actor in ('user', 'agent', 'system')),
+  action_type text not null,
+  entity_type text,
+  entity_id uuid,
+  summary text not null,
+  metadata jsonb,
+  created_at timestamp with time zone not null default timezone('utc'::text, now())
+);
+
+-- Create indexes for efficient querying
+create index activity_log_user_id_created_at_idx on public.activity_log (user_id, created_at desc);
+create index activity_log_user_id_action_type_idx on public.activity_log (user_id, action_type);
+create index activity_log_metadata_idx on public.activity_log using gin (metadata);
+
+-- Enable Row Level Security
+alter table public.activity_log enable row level security;
+
+-- RLS Policies
+-- Users can view their own activity
+create policy "Users can view their own activity" on public.activity_log
+  for select using (auth.uid() = user_id);
+
+-- Users can insert their own activity
+create policy "Users can insert their own activity" on public.activity_log
+  for insert with check (auth.uid() = user_id);
+
+-- Disallow UPDATE and DELETE for MVP (activity is append-only)
+-- If needed later, add policies for specific use cases
+
+-- Optional: Add a comment for documentation
+comment on table public.activity_log is 'Stores per-user activity feed for tasks, projects, and agent actions';
+comment on column public.activity_log.actor is 'Who performed the action: user, agent, or system';
+comment on column public.activity_log.action_type is 'Type of action (e.g., TASK_CREATED, TASK_COMPLETED, PLAN_GENERATED)';
+comment on column public.activity_log.entity_type is 'Type of entity affected (e.g., task, project, note)';
+comment on column public.activity_log.entity_id is 'UUID of the affected entity';
+comment on column public.activity_log.summary is 'Human-readable summary of the activity';
+comment on column public.activity_log.metadata is 'Additional context (changed fields, counts, etc.)';

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -1,0 +1,131 @@
+import { supabase } from './supabase';
+import { LogActivityParams, ActivityLog } from '@/types/activity';
+
+/**
+ * Log an activity entry to the activity_log table.
+ * This function NEVER throws - it logs errors but allows the main action to proceed.
+ *
+ * @param params - Activity log parameters
+ * @returns Promise that resolves with the created log entry or null if failed
+ */
+export async function logActivity(params: LogActivityParams): Promise<ActivityLog | null> {
+  // Skip if Supabase is not configured
+  if (!supabase) {
+    console.warn('[activity] Supabase not configured, skipping activity log');
+    return null;
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from('activity_log')
+      .insert({
+        user_id: params.userId,
+        actor: params.actor,
+        action_type: params.actionType,
+        entity_type: params.entityType || null,
+        entity_id: params.entityId || null,
+        summary: params.summary,
+        metadata: params.metadata || null,
+      })
+      .select()
+      .single();
+
+    if (error) {
+      console.warn('[activity] Failed to log activity:', error.message);
+      return null;
+    }
+
+    return data;
+  } catch (err) {
+    console.warn('[activity] Exception while logging activity:', err);
+    return null;
+  }
+}
+
+/**
+ * Fetch activity logs for the current user with pagination and optional filters.
+ *
+ * @param options - Query options
+ * @returns Promise with array of activity logs
+ */
+export async function fetchActivityLogs(options: {
+  limit?: number;
+  offset?: number;
+  actor?: string;
+  entityType?: string;
+  actionType?: string;
+}): Promise<ActivityLog[]> {
+  if (!supabase) {
+    throw new Error('Supabase not configured');
+  }
+
+  let query = supabase
+    .from('activity_log')
+    .select('*')
+    .order('created_at', { ascending: false });
+
+  // Apply filters
+  if (options.actor) {
+    query = query.eq('actor', options.actor);
+  }
+  if (options.entityType) {
+    query = query.eq('entity_type', options.entityType);
+  }
+  if (options.actionType) {
+    query = query.eq('action_type', options.actionType);
+  }
+
+  // Apply pagination
+  if (options.limit) {
+    query = query.limit(options.limit);
+  }
+  if (options.offset) {
+    query = query.range(options.offset, options.offset + (options.limit || 50) - 1);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    console.error('[activity] Failed to fetch activity logs:', error);
+    throw error;
+  }
+
+  return data || [];
+}
+
+/**
+ * Get the total count of activity logs for the current user.
+ * Useful for pagination.
+ */
+export async function getActivityLogCount(filters?: {
+  actor?: string;
+  entityType?: string;
+  actionType?: string;
+}): Promise<number> {
+  if (!supabase) {
+    throw new Error('Supabase not configured');
+  }
+
+  let query = supabase
+    .from('activity_log')
+    .select('id', { count: 'exact', head: true });
+
+  if (filters?.actor) {
+    query = query.eq('actor', filters.actor);
+  }
+  if (filters?.entityType) {
+    query = query.eq('entity_type', filters.entityType);
+  }
+  if (filters?.actionType) {
+    query = query.eq('action_type', filters.actionType);
+  }
+
+  const { count, error } = await query;
+
+  if (error) {
+    console.error('[activity] Failed to get activity log count:', error);
+    throw error;
+  }
+
+  return count || 0;
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,5 +1,6 @@
 import { supabase } from './supabase';
 import { Task } from '@/types/task';
+import { logActivity } from './activity';
 
 // Map database row → Task object.
 // Supports both old schema (completed boolean) and new schema (status text).
@@ -61,9 +62,26 @@ export const db = {
       throw error;
     }
     console.log('[db.addTask] Insert succeeded');
+
+    // Log activity (non-blocking)
+    if (task.user_id) {
+      logActivity({
+        userId: task.user_id,
+        actor: 'user',
+        actionType: 'TASK_CREATED',
+        entityType: 'task',
+        entityId: task.id,
+        summary: `Created task: ${task.title}`,
+        metadata: {
+          category: task.category,
+          priority: task.priority,
+          estimatedMinutes: task.estimatedMinutes,
+        },
+      });
+    }
   },
 
-  async updateTask(task: Task) {
+  async updateTask(task: Task, previousStatus?: string) {
     if (!supabase) throw new Error('Supabase not configured');
     console.log('[db.updateTask] Updating task:', task.id);
     const { error } = await supabase
@@ -86,9 +104,57 @@ export const db = {
       throw error;
     }
     console.log('[db.updateTask] Update succeeded');
+
+    // Log activity (non-blocking)
+    if (task.user_id) {
+      // Check if this is a status change to completed/uncompleted
+      if (previousStatus && previousStatus !== task.status) {
+        if (task.status === 'done') {
+          logActivity({
+            userId: task.user_id,
+            actor: 'user',
+            actionType: 'TASK_COMPLETED',
+            entityType: 'task',
+            entityId: task.id,
+            summary: `Completed task: ${task.title}`,
+            metadata: { previousStatus },
+          });
+        } else if (previousStatus === 'done') {
+          logActivity({
+            userId: task.user_id,
+            actor: 'user',
+            actionType: 'TASK_UNCOMPLETED',
+            entityType: 'task',
+            entityId: task.id,
+            summary: `Uncompleted task: ${task.title}`,
+            metadata: { newStatus: task.status },
+          });
+        } else {
+          logActivity({
+            userId: task.user_id,
+            actor: 'user',
+            actionType: 'TASK_UPDATED',
+            entityType: 'task',
+            entityId: task.id,
+            summary: `Updated task: ${task.title}`,
+            metadata: { previousStatus, newStatus: task.status },
+          });
+        }
+      } else {
+        // General update
+        logActivity({
+          userId: task.user_id,
+          actor: 'user',
+          actionType: 'TASK_UPDATED',
+          entityType: 'task',
+          entityId: task.id,
+          summary: `Updated task: ${task.title}`,
+        });
+      }
+    }
   },
 
-  async deleteTask(taskId: string) {
+  async deleteTask(taskId: string, userId?: string, taskTitle?: string) {
     if (!supabase) throw new Error('Supabase not configured');
     console.log('[db.deleteTask] Deleting task:', taskId);
     const { error, count } = await supabase.from('tasks').delete({ count: 'exact' }).eq('id', taskId);
@@ -97,5 +163,17 @@ export const db = {
       throw error;
     }
     console.log('[db.deleteTask] Rows deleted:', count);
+
+    // Log activity (non-blocking)
+    if (userId) {
+      logActivity({
+        userId,
+        actor: 'user',
+        actionType: 'TASK_DELETED',
+        entityType: 'task',
+        entityId: taskId,
+        summary: `Deleted task${taskTitle ? `: ${taskTitle}` : ''}`,
+      });
+    }
   }
 };

--- a/src/lib/ideas.ts
+++ b/src/lib/ideas.ts
@@ -1,6 +1,7 @@
 
 import { supabase } from './supabase';
 import { Idea, IdeaStatus } from '@/types/idea';
+import { logActivity } from './activity';
 
 export const ideasDb = {
   async fetchIdeas(): Promise<Idea[]> {
@@ -23,7 +24,7 @@ export const ideasDb = {
 
   async addIdea(idea: Omit<Idea, 'id' | 'created_at' | 'user_id'> & { user_id: string }): Promise<Idea> {
     if (!supabase) throw new Error('Supabase not configured');
-    
+
     const { data, error } = await supabase
       .from('ideas')
       .insert({
@@ -36,31 +37,74 @@ export const ideasDb = {
       .single();
 
     if (error) throw error;
-    return {
+
+    const result = {
       ...data,
       created_at: new Date(data.created_at).getTime(),
     };
+
+    // Log activity (non-blocking)
+    logActivity({
+      userId: idea.user_id,
+      actor: 'user',
+      actionType: 'PROJECT_CREATED',
+      entityType: 'project',
+      entityId: data.id,
+      summary: `Created project: ${idea.title}`,
+      metadata: {
+        status: idea.status,
+      },
+    });
+
+    return result;
   },
 
-  async updateIdeaStatus(id: string, status: IdeaStatus): Promise<void> {
+  async updateIdeaStatus(id: string, status: IdeaStatus, userId?: string, title?: string): Promise<void> {
     if (!supabase) throw new Error('Supabase not configured');
-    
+
     const { error } = await supabase
       .from('ideas')
       .update({ status })
       .eq('id', id);
 
     if (error) throw error;
+
+    // Log activity (non-blocking)
+    if (userId) {
+      logActivity({
+        userId,
+        actor: 'user',
+        actionType: 'PROJECT_UPDATED',
+        entityType: 'project',
+        entityId: id,
+        summary: `Updated project status${title ? ` for "${title}"` : ''}: ${status}`,
+        metadata: {
+          newStatus: status,
+        },
+      });
+    }
   },
 
-  async deleteIdea(id: string): Promise<void> {
+  async deleteIdea(id: string, userId?: string, title?: string): Promise<void> {
     if (!supabase) throw new Error('Supabase not configured');
-    
+
     const { error } = await supabase
       .from('ideas')
       .delete()
       .eq('id', id);
 
     if (error) throw error;
+
+    // Log activity (non-blocking)
+    if (userId) {
+      logActivity({
+        userId,
+        actor: 'user',
+        actionType: 'PROJECT_DELETED',
+        entityType: 'project',
+        entityId: id,
+        summary: `Deleted project${title ? `: ${title}` : ''}`,
+      });
+    }
   }
 };

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -1,0 +1,41 @@
+export type ActivityActor = 'user' | 'agent' | 'system';
+
+export type ActivityActionType =
+  | 'TASK_CREATED'
+  | 'TASK_UPDATED'
+  | 'TASK_COMPLETED'
+  | 'TASK_UNCOMPLETED'
+  | 'TASK_DELETED'
+  | 'PROJECT_CREATED'
+  | 'PROJECT_UPDATED'
+  | 'PROJECT_DELETED'
+  | 'NOTE_CREATED'
+  | 'NOTE_UPDATED'
+  | 'NOTE_DELETED'
+  | 'PLAN_GENERATED'
+  | 'TASKS_CREATED_FROM_PLAN'
+  | 'AGENT_ERROR';
+
+export type ActivityEntityType = 'task' | 'project' | 'note' | 'plan' | null;
+
+export interface ActivityLog {
+  id: string;
+  user_id: string;
+  actor: ActivityActor;
+  action_type: ActivityActionType;
+  entity_type: ActivityEntityType;
+  entity_id: string | null;
+  summary: string;
+  metadata: Record<string, any> | null;
+  created_at: string; // ISO timestamp
+}
+
+export interface LogActivityParams {
+  userId: string;
+  actor: ActivityActor;
+  actionType: ActivityActionType;
+  entityType?: ActivityEntityType;
+  entityId?: string;
+  summary: string;
+  metadata?: Record<string, any>;
+}


### PR DESCRIPTION
Closes #27

## What this PR does
Automated fix for: **Implement activity_log table (per-user rows) + logging hooks for tasks/projects/agent actions**

## Issue description

Context

We already have an Activity Log UI, but events aren’t persisted. We need a durable, queryable activity feed so each user can review what happened (including agent actions) with proper Supabase RLS.

Goal

Add a database table that stores activity rows per user, enforce RLS, and implement the backend/client logic to:

write activity entries on key actions

read/paginate/filter and render them in the Activity Log UI

Database design (Supabase Postgres)

Create a single table: public.activity_log

Schema (suggested)

id uuid primary key default gen_random_uuid()

user_id uuid not null (the owner of the feed; usually equals auth.uid())

actor text not null ('user' | 'agent' | 'system')

action_type text not null
Examples: TASK_CREATED, TASK_UPDATED, TASK_COMPLETED, TASK_DELETED, PROJECT_CREATED, PLAN_GENERATED, AGENT_ERROR

entity_type text null ('task' | 'project' | 'note' | 'plan' | etc.)

entity_id uuid null

summary text not null (human-readable)

metadata jsonb null (changed

## Agent output
<details>
<summary>Click to expand</summary>

```
Error: Reached max turns (30)
```

</details>

---
*Generated by [Jarvis22](https://github.com/BrianTruong23/Jarvis22)*
